### PR TITLE
Enable caching

### DIFF
--- a/setup_perf_host.yml
+++ b/setup_perf_host.yml
@@ -44,6 +44,7 @@
     external_lb_vip_address: 127.0.0.1
     keystone_rabbitmq_password: password
     container_address: 127.0.0.1
+    keystone_cache_backend_argument: url:127.0.0.1:11211
     galera_root_password: password
     galera_root_user: root
     galera_ignore_cluster_state: true


### PR DESCRIPTION
memcached should be enabled in os_keystone by default, but it's not, so
we have to pass an extra variable to the playbook.

For referenced, this is also fixed upstream here:

```
https://review.openstack.org/#/c/326748/
```

Issue #14
